### PR TITLE
Enhancements on accessing gist, users, search and issues api from WebService::Github directly 

### DIFF
--- a/lib/WebService/GitHub.rakumod
+++ b/lib/WebService/GitHub.rakumod
@@ -2,15 +2,32 @@ use v6;
 
 use WebService::GitHub::Role;
 use WebService::GitHub::OAuth;
+use WebService::GitHub::Gist;
+use WebService::GitHub::Users;
+use WebService::GitHub::Search;
+use WebService::GitHub::Issues;
 
 class WebService::GitHub does WebService::GitHub::Role {
     # does WebService::GitHub::Role::Debug if %*ENV<DEBUG_GITHUB>;
+    method gists() {
+        state $obj = WebService::GitHub::Gist.new: |self.attrs;
+        $obj;
+    }
+    method users() {
+        state $obj = WebService::GitHub::Users.new: |self.attrs;
+        $obj;
+    }
+    method search() {
+        state $obj = WebService::GitHub::Search.new: |self.attrs;
+        $obj;
+    }
+    method issues() {
+        state $obj = WebService::GitHub::Issues.new: |self.attrs;
+        $obj;
+    }
+    method attrs() {
+        self.^attributes(:local).map( -> $attr { $attr.name.split('!')[*-1] => $attr.get_value(self) } ).Hash
+    }
 }
 
-sub rate-limit-remaining(--> Str) is export {
-    # make a "free" rate-limit request:
-    #   GET /rate_limit
-    my $c = WebService::GitHub.new;
-    my $resp = $c.request('/rate_limit');
-    return $resp.x-ratelimit-remaining;
-}
+

--- a/lib/WebService/GitHub/Issues.rakumod
+++ b/lib/WebService/GitHub/Issues.rakumod
@@ -1,6 +1,5 @@
 use v6;
 
-use WebService::GitHub;
 use WebService::GitHub::Role;
 
 class WebService::GitHub::Issues does WebService::GitHub::Role {
@@ -20,7 +19,7 @@ class WebService::GitHub::Issues does WebService::GitHub::Role {
         my @issues = self.show(:$repo, state => 'all').data.list;
         my @issue-data;
         for @issues -> $issue {
-            die "Limit exceeded, please use auth" if !rate-limit-remaining();
+            die "Limit exceeded, please use auth" if !self.rate-limit-remaining();
             my $this-issue = self.single-issue(:$repo, issue => $issue<number>).data;
             for $this-issue.kv -> $k, $value { # merge issues
                 if (!$issue{$k}) {

--- a/lib/WebService/GitHub/Role.rakumod
+++ b/lib/WebService/GitHub/Role.rakumod
@@ -43,7 +43,7 @@ role WebService::GitHub::Role {
 
     submethod BUILD(*%args) {
         if %args<with>:exists {
-            for %args<with> -> $n {
+            for |%args<with> -> $n {
                 my $class = "WebService::GitHub::Role::$n";
                 require ::($class);
                 self does ::($class);
@@ -158,5 +158,12 @@ role WebService::GitHub::Role {
     }
     method handle_response($response) {
         return $response
+    }
+
+    method rate-limit-remaining(--> Str)  {
+        # make a "free" rate-limit request:
+        #   GET /rate_limit
+        my $resp = self.request('/rate_limit');
+        return $resp.x-ratelimit-remaining;
     }
 }

--- a/t/02-response.t
+++ b/t/02-response.t
@@ -11,7 +11,7 @@ my $raw = HTTP::Response.new;
 $raw.parse($content);
 
 if rate-limit-remaining() {
-    my $response = WebService::GitHub::Response.new(raw => $raw);
+    my $response = WebService::GitHub::Response.new(:$raw);
     is $response.header('X-GitHub-Request-Id'), '3CB4420C:151E8:2C08375:5620F57C', 'X-GitHub-Request-Id';
     ok $response.is-success;
     is $response.next-page-url, 'https://api.github.com/search/repositories?q=perl&page=2', 'next-page-url';

--- a/t/02-response.t
+++ b/t/02-response.t
@@ -9,8 +9,8 @@ $content ~~ s:g/\r?\n/\r\n/;
 # dummy hack
 my $raw = HTTP::Response.new;
 $raw.parse($content);
-
-if rate-limit-remaining() {
+my $gh = WebService::GitHub.new;
+if $gh.rate-limit-remaining() {
     my $response = WebService::GitHub::Response.new(:$raw);
     is $response.header('X-GitHub-Request-Id'), '3CB4420C:151E8:2C08375:5620F57C', 'X-GitHub-Request-Id';
     ok $response.is-success;

--- a/t/10-public.t
+++ b/t/10-public.t
@@ -3,8 +3,9 @@ use Test;
 use WebService::GitHub;
 
 ok(1);
+my $gh = WebService::GitHub.new;
 
-if ((%*ENV<TRAVIS> && rate-limit-remaining()) || %*ENV<GH_TOKEN>) {
+if ((%*ENV<TRAVIS> && $gh.rate-limit-remaining()) || %*ENV<GH_TOKEN>) {
     diag "running on travis or with token";
     my $gh = WebService::GitHub.new;
     my $user = $gh.request('/users/fayland').data;

--- a/t/11-users.t
+++ b/t/11-users.t
@@ -4,8 +4,9 @@ use WebService::GitHub;
 use WebService::GitHub::Users;
 
 ok(1);
+my $gh = WebService::GitHub.new;
 
-if ((%*ENV<TRAVIS> && rate-limit-remaining()) || %*ENV<GH_TOKEN>) {
+if ((%*ENV<TRAVIS> && $gh.rate-limit-remaining()) || %*ENV<GH_TOKEN>) {
     diag "running on travis or with token";
     my $gh-user = WebService::GitHub::Users.new;
     my $user = $gh-user.show("JJ").data;

--- a/t/12-issues.t
+++ b/t/12-issues.t
@@ -4,8 +4,9 @@ use WebService::GitHub;
 use WebService::GitHub::Issues;
 
 ok(1);
+my $gh = WebService::GitHub.new;
 
-if ((%*ENV<TRAVIS> && rate-limit-remaining()) || %*ENV<GH_TOKEN>) {
+if ((%*ENV<TRAVIS> && $gh.rate-limit-remaining()) || %*ENV<GH_TOKEN>) {
     diag "running on travis or with token";
     my $gh = WebService::GitHub::Issues.new;
     my $issues = $gh.show(repo => 'fayland/perl6-WebService-GitHub').data;

--- a/t/30-cache.t
+++ b/t/30-cache.t
@@ -8,9 +8,9 @@ if (%*ENV<TRAVIS>) {
     my ($gh, $res, $user, $old_etag, $old_date);
 
     my $first-test = 0;
+    $gh = WebService::GitHub.new;
 
-    if rate-limit-remaining() {
-        $gh = WebService::GitHub.new;
+    if $gh.rate-limit-remaining() {
         $res = $gh.request('/users/fayland');
         $user = $res.data;
         is $user<login>, 'fayland', 'login ok';
@@ -20,7 +20,7 @@ if (%*ENV<TRAVIS>) {
         $first-test = 0
     }
 
-    if $first-test && rate-limit-remaining() {
+    if $first-test && $gh.rate-limit-remaining() {
         $res = $gh.request('/users/fayland');
         $user = $res.data;
         is $user<login>, 'fayland', 'login ok';


### PR DESCRIPTION
Moved `rate-limit-remaining()` from `WebService::Github` to `WebService::GitHub::Role` to be accessed from any class and to prevent Circular module loading if user `use` both `WebService::Github` and `WebService::Github::Issues` for example.

Added `gists`, `users`, `issues`, `search` methods to `WebService::Github` to access them directly.